### PR TITLE
Fix author button placement

### DIFF
--- a/author/index.html
+++ b/author/index.html
@@ -35,6 +35,7 @@
           علاقتنا اليومية بالتقنية. يقود برامج تدريبية مبتكرة تساعد الأفراد
           والمؤسسات على استخدام أدوات الذكاء الاصطناعي في الكتابة وتصميم تجارب
           تعليمية وتعزيز التفكير الإبداعي.</p>
+          <a href="../assets/docs/AuthorBio.pdf" class="btn" target="_blank" rel="noopener">اقرأ المزيد</a>
           <h2 style="margin-top:2rem;">تواصل مع الكاتب</h2>
 
           <form action="https://formsubmit.co/YOUR_EMAIL@example.com"
@@ -58,12 +59,6 @@
 
             <button type="submit" class="btn">إرسال</button>
           </form>
-
-          <a href="../assets/docs/AuthorBio.pdf"
-             class="btn"
-             target="_blank" rel="noopener">
-             اقرأ المزيد
-          </a>
 
         </div>
       </section>


### PR DESCRIPTION
## Summary
- move the "اقرأ المزيد" button below the bio paragraphs and before the contact section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e65a7c980832bb9a60bcbe6c0b1cd