### PR TITLE
Fix image paths in workshops carousel

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -31,16 +31,16 @@
   <div id="workshopsCarousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="8000">
     <div class="carousel-inner">
       <div class="carousel-item active">
-        <img src="/assets/img/workshops/1.png" class="d-block w-100" alt="ورشة 1">
+        <img src="/Mindshift/assets/img/workshops/1.png" class="d-block w-100" alt="ورشة 1">
       </div>
       <div class="carousel-item">
-        <img src="/assets/img/workshops/2.png" class="d-block w-100" alt="ورشة 2">
+        <img src="/Mindshift/assets/img/workshops/2.png" class="d-block w-100" alt="ورشة 2">
       </div>
       <div class="carousel-item">
-        <img src="/assets/img/workshops/3.png" class="d-block w-100" alt="ورشة 3">
+        <img src="/Mindshift/assets/img/workshops/3.png" class="d-block w-100" alt="ورشة 3">
       </div>
       <div class="carousel-item">
-        <img src="/assets/img/workshops/4.png" class="d-block w-100" alt="ورشة 4">
+        <img src="/Mindshift/assets/img/workshops/4.png" class="d-block w-100" alt="ورشة 4">
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- update the image paths in `workshops/index.html` so they point to `/Mindshift/assets/img/workshops` instead of `/assets/img/workshops`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d49cd277c832b9f11280766d13c72