### PR TITLE
Add subscription button linked to Google Form

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -102,6 +102,12 @@
   </ul>
 </div>
 
+<div class="text-center my-5">
+  <a href="https://forms.gle/upKY34SEiwdDFfyY9" target="_blank" class="btn btn-primary btn-lg">
+    📩 اشترك الآن 
+  </a>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link to a new subscription form after the PDF links in `workshops/index.html`

## Testing
- `grep -n forms.gle -n workshops/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687d60dce9e4832bbbd74baf3778fe4d