### PR TITLE
Add GA4 tracking to workshops page

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -33,6 +33,14 @@
       background-color: #fff;
     }
   </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7ZZP1M8TMK"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7ZZP1M8TMK');
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- add GA4 tag snippet to `workshops/index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d7114a1bc832b80f7867bcff8e8a9