### PR TITLE
Add GA4 tracking script on workshops page

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="ar" dir="rtl">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7ZZP1M8TMK"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-7ZZP1M8TMK');
+</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>الورشات - عقلية قيد التحديث</title>
@@ -33,14 +41,6 @@
       background-color: #fff;
     }
   </style>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7ZZP1M8TMK"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-7ZZP1M8TMK');
-  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- move Google Analytics tag to the top of the workshops page head section

## Testing
- `grep -n gtag workshops/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687e37978b70832b9794b6096fbd79b1