### PR TITLE
Fix slider image cropping on workshops page

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -74,19 +74,27 @@
   <div id="workshopsCarousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="8000">
     <div class="carousel-inner">
       <div class="carousel-item text-center active">
-        <img src="/Mindshift/assets/img/workshops/1.png" class="d-block mx-auto mb-2" style="max-width: 600px; height: auto;" alt="ورشة 1" />
+        <div class="flex justify-center items-center overflow-hidden">
+          <img src="/Mindshift/assets/img/workshops/1.png" class="d-block mx-auto mb-2" style="width: 100%; height: auto; max-height: 90vh; object-fit: contain;" alt="ورشة 1" />
+        </div>
         <button class="btn btn-outline-light btn-sm" disabled>طالع التفاصيل ⏷</button>
       </div>
       <div class="carousel-item text-center">
-        <img src="/Mindshift/assets/img/workshops/2.png" class="d-block mx-auto mb-2" style="max-width: 600px; height: auto;" alt="ورشة 2" />
+        <div class="flex justify-center items-center overflow-hidden">
+          <img src="/Mindshift/assets/img/workshops/2.png" class="d-block mx-auto mb-2" style="width: 100%; height: auto; max-height: 90vh; object-fit: contain;" alt="ورشة 2" />
+        </div>
         <button class="btn btn-outline-light btn-sm" disabled>طالع التفاصيل ⏷</button>
       </div>
       <div class="carousel-item text-center">
-        <img src="/Mindshift/assets/img/workshops/3.png" class="d-block mx-auto mb-2" style="max-width: 600px; height: auto;" alt="ورشة 3" />
+        <div class="flex justify-center items-center overflow-hidden">
+          <img src="/Mindshift/assets/img/workshops/3.png" class="d-block mx-auto mb-2" style="width: 100%; height: auto; max-height: 90vh; object-fit: contain;" alt="ورشة 3" />
+        </div>
         <button class="btn btn-outline-light btn-sm" disabled>طالع التفاصيل ⏷</button>
       </div>
       <div class="carousel-item text-center">
-        <img src="/Mindshift/assets/img/workshops/4.png" class="d-block mx-auto mb-2" style="max-width: 600px; height: auto;" alt="ورشة 4" />
+        <div class="flex justify-center items-center overflow-hidden">
+          <img src="/Mindshift/assets/img/workshops/4.png" class="d-block mx-auto mb-2" style="width: 100%; height: auto; max-height: 90vh; object-fit: contain;" alt="ورشة 4" />
+        </div>
         <button class="btn btn-outline-light btn-sm" disabled>طالع التفاصيل ⏷</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update workshop slider images to use `object-fit: contain`
- wrap images in flex centering wrapper for better scaling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ec1637990832ba7985c01e0c66b82