### PR TITLE
Remove workshop dates from PDF titles

### DIFF
--- a/workshops/index.html
+++ b/workshops/index.html
@@ -110,22 +110,22 @@
   <ul class="list-group list-group-flush">
     <li class="list-group-item bg-dark text-white">
       <a href="/Mindshift/assets/docs/workshops/1.pdf" target="_blank" class="text-decoration-none text-info">
-        1. من الفكرة إلى الإبداع – كيف تبني مشروعك انطلاقًا من بحث ذكي (الثلاثاء 29-7)
+        1. من الفكرة إلى الإبداع – كيف تبني مشروعك انطلاقًا من بحث ذكي
       </a>
     </li>
     <li class="list-group-item bg-dark text-white">
       <a href="/Mindshift/assets/docs/workshops/2.pdf" target="_blank" class="text-decoration-none text-info">
-        2. من الفكرة إلى الجمهور – بناء هوية بصرية احترافية على Pinterest (الجمعة 1-8)
+        2. من الفكرة إلى الجمهور – بناء هوية بصرية احترافية على Pinterest
       </a>
     </li>
     <li class="list-group-item bg-dark text-white">
       <a href="/Mindshift/assets/docs/workshops/3.pdf" target="_blank" class="text-decoration-none text-info">
-        3. من الفكرة إلى الصورة – كيف تصمّم هويتك باستخدام MidJourney وCanva (الثلاثاء 5-8)
+        3. من الفكرة إلى الصورة – كيف تصمّم هويتك باستخدام MidJourney وCanva
       </a>
     </li>
     <li class="list-group-item bg-dark text-white">
       <a href="/Mindshift/assets/docs/workshops/4.pdf" target="_blank" class="text-decoration-none text-info">
-        4. من السؤال إلى الرؤية – تصميم استبيانات واستطلاعات رأي ذكية (الجمعة 8-8)
+        4. من السؤال إلى الرؤية – تصميم استبيانات واستطلاعات رأي ذكية
       </a>
     </li>
   </ul>


### PR DESCRIPTION
## Summary
- drop all workshop date references from PDF link titles to keep navigation concise

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c9780cac832ba7aa9961fa550943